### PR TITLE
Fix typos in docs and source

### DIFF
--- a/R/switchcase.r
+++ b/R/switchcase.r
@@ -75,13 +75,13 @@ ifnull <- function(x) {
 #'   statement is applicable can be modeled by setting the first element of an
 #'   alternative (which would normally contain the test condition) to
 #'   \code{NULL}. If multiple defaults are found, only the first one is
-#'   executed. Technical note: All code is executed in the enviroment from which
+#'   executed. Technical note: All code is executed in the environment from which
 #'   \code{switchCase()} is called so it is easy to access variables and
 #'   functions from there.
 #'
 #' @return The return value of the 'case' alternative that is executed last. If
 #'   there is no applicable alternative or no applicable alternative returns a
-#'   value then nothing is retuned.
+#'   value then nothing is returned.
 #'
 #' @family switchcase
 #' @export
@@ -126,12 +126,12 @@ ifnull <- function(x) {
 #'   alt(
 #'     ..expr > 35 & ..expr <= 40,
 #'     { cat("Your body mass index is ", ind, " which is severely obese.\n") },
-#'     "severly obese"
+#'     "severely obese"
 #'   ),
 #'   alt(
 #'     ..expr > 40,
 #'     { cat("Your body mass index is ", ind, " which is Very severely obese.\n") },
-#'     "very severly obese"
+#'     "very severely obese"
 #'   )
 #'  )
 #' }
@@ -192,7 +192,7 @@ switchCase <- function(expr, ..., break.case = TRUE) {
 #'   four elements: The test condition, the code that is executed if the
 #'   condition evaluates to \code{TRUE}, an optional return value which
 #'   \code{\link{switchCase}()} will return if the condition is met and after
-#'   the branch code has ben executed, and an optional logical value indicating
+#'   the branch code has been executed, and an optional logical value indicating
 #'   if the switch-case construct will be left after this branch has been
 #'   executed.
 #'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Joachim Zuckarelli
 **New: switchcase tutorial on YouTube**
 
 To learn more about the `switchcase` package and how it relates to R’s
-buit-in primitive function `switch()` please watch the new `switchcase`
+built-in primitive function `switch()` please watch the new `switchcase`
 tutorial on [YouTube](https://youtu.be/3ybF8u_PE7w).
 
 # Introduction
@@ -97,12 +97,12 @@ switchCase(
   alt(
     ..expr > 35 & ..expr <= 40,
     { cat("Your body mass index is ", ind, " which is severely obese.\n") },
-    "severly obese"
+    "severely obese"
   ),
   alt(
     ..expr > 40,
     { cat("Your body mass index is ", ind, " which is Very severely obese.\n") },
-    "very severly obese"
+    "very severely obese"
   )
  )
 }
@@ -169,4 +169,4 @@ variables of your script or function in which `switchCase()` is used.
 # Contact
 
 Follow me on Twitter (<https://twitter.com/jsugarelli>) to stay
-up-to-date on new developement around the `switchcase` package.
+up-to-date on new development around the `switchcase` package.

--- a/man/alt.Rd
+++ b/man/alt.Rd
@@ -35,7 +35,7 @@ The \code{\link{alt}()} function is used to build alternative 'case'
   four elements: The test condition, the code that is executed if the
   condition evaluates to \code{TRUE}, an optional return value which
   \code{\link{switchCase}()} will return if the condition is met and after
-  the branch code has ben executed, and an optional logical value indicating
+  the branch code has been executed, and an optional logical value indicating
   if the switch-case construct will be left after this branch has been
   executed.
 }

--- a/man/switchCase.Rd
+++ b/man/switchCase.Rd
@@ -38,7 +38,7 @@ via the \code{...} argument.}
 \value{
 The return value of the 'case' alternative that is executed last. If
   there is no applicable alternative or no applicable alternative returns a
-  value then nothing is retuned.
+  value then nothing is returned.
 }
 \description{
 \code{switchCase()} provides the functionality of a typical
@@ -63,7 +63,7 @@ The \code{expr} argument is the expression that is evaluated and
   statement is applicable can be modeled by setting the first element of an
   alternative (which would normally contain the test condition) to
   \code{NULL}. If multiple defaults are found, only the first one is
-  executed. Technical note: All code is executed in the enviroment from which
+  executed. Technical note: All code is executed in the environment from which
   \code{switchCase()} is called so it is easy to access variables and
   functions from there.
 }
@@ -107,12 +107,12 @@ switchCase(
   alt(
     ..expr > 35 & ..expr <= 40,
     { cat("Your body mass index is ", ind, " which is severely obese.\n") },
-    "severly obese"
+    "severely obese"
   ),
   alt(
     ..expr > 40,
     { cat("Your body mass index is ", ind, " which is Very severely obese.\n") },
-    "very severly obese"
+    "very severely obese"
   )
  )
 }

--- a/readme.rmd
+++ b/readme.rmd
@@ -10,7 +10,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 **New: switchcase tutorial on YouTube**
 
-To learn more about the `switchcase` package and how it relates to R's buit-in primitive function `switch()` please watch the new `switchcase` tutorial on [YouTube](https://youtu.be/3ybF8u_PE7w).
+To learn more about the `switchcase` package and how it relates to R's built-in primitive function `switch()` please watch the new `switchcase` tutorial on [YouTube](https://youtu.be/3ybF8u_PE7w).
 
 
 # Introduction
@@ -79,12 +79,12 @@ switchCase(
   alt(
     ..expr > 35 & ..expr <= 40,
     { cat("Your body mass index is ", ind, " which is severely obese.\n") },
-    "severly obese"
+    "severely obese"
   ),
   alt(
     ..expr > 40,
     { cat("Your body mass index is ", ind, " which is Very severely obese.\n") },
-    "very severly obese"
+    "very severely obese"
   )
  )
 }
@@ -112,4 +112,4 @@ All code in the alternative 'case' branches is evaluated in the environment from
 
 
 # Contact
-Follow me on Twitter (https://twitter.com/jsugarelli) to stay up-to-date on new developement around the `switchcase` package.
+Follow me on Twitter (https://twitter.com/jsugarelli) to stay up-to-date on new development around the `switchcase` package.


### PR DESCRIPTION
## Summary
- fix various typos (`been`, `returned`, `severely`, `built-in`, `development`, `environment`)
- keep docs in sync

## Testing
- `R -q -e "devtools::document()"` *(fails: no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_685553fab53c832c9d3f820dafbf5a2c